### PR TITLE
Support for shortened IPv4 addresses with ports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ if (NOT IPV6_PARSE_LIBRARY_ONLY)
     CHECK_INCLUDE_FILES(netinet/in.h HAVE_NETINET_IN_H)
     CHECK_INCLUDE_FILES(arpa/inet.h HAVE_ARPA_INET_H)
     CHECK_INCLUDE_FILES(ws2tcpip.h HAVE_WS_2_TCPIP_H)
+    CHECK_INCLUDE_FILES(assert.h HAVE_ASSERT_H)
 
     configure_file(ipv6_test_config.h.in ipv6_test_config.h)
     set(IPV6_TEST_CONFIG_HEADER_PATH ${CMAKE_CURRENT_BINARY_DIR})

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ License: MIT
   - CIDR notation `ffff::/80`
   - Port notation `[::1]:1119`
   - IPv4 `10.11.82.1`, `10.11.82.1:5555`, `10.0.0.0/8`
+  - IPv4 addresses with less than 4 octets (1 -> 0.0.0.1, 1.2 -> 1.0.0.2, 1.2.3 -> 1.2.0.3)
+  - Basic IPv4 with port 10.1:8080 -> 10.0.0.1:8080
   - Combinations of the above `[ffff::1.2.3.4/128]:1119`
 - Single function to parse both IPv4 and IPv6 addresses and ports
 - Rich diagnostic information regarding addresses formatting

--- a/ipv6.h
+++ b/ipv6.h
@@ -19,6 +19,8 @@
 //   - CIDR notation `ffff::/80`
 //   - Port notation `[::1]:1119`
 //   - IPv4 `10.11.82.1`, `10.11.82.1:5555`, `10.0.0.0/8`
+//   - IPv4 addresses with less than 4 octets (1 -> 0.0.0.1, 1.2 -> 1.0.0.2, 1.2.3 -> 1.2.0.3)
+//   - Basic IPv4 with port 10.1:8080 -> 10.0.0.1:8080
 //   - Combinations of the above `[ffff::1.2.3.4/128]:1119`
 // - Single function to parse both IPv4 and IPv6 addresses and ports
 // - Rich diagnostic information regarding addresses formatting

--- a/ipv6_test_config.h.in
+++ b/ipv6_test_config.h.in
@@ -4,3 +4,4 @@
 #cmakedefine HAVE_SYS_SOCKET_H 1
 #cmakedefine HAVE_NETINET_IN_H 1
 #cmakedefine HAVE_ARPA_INET_H 1
+#cmakedefine HAVE_ASSERT_H 1


### PR DESCRIPTION
1 -> 0.0.0.1
1.2 -> 1.0.0.2
1.2.3 -> 1.2.0.3
1.2:3 -> 1.0.0.2:3

Updated postive and negative tests and documentation

https://github.com/jrepp/ipv6-parse/issues/5