### PR TITLE
Update Ubuntu versions in release workflow to modern LTS releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,13 +25,13 @@ jobs:
       matrix:
         include:
           # Linux builds
-          - os: ubuntu-20.04
-            compiler: gcc
-            build_type: Release
           - os: ubuntu-22.04
             compiler: gcc
             build_type: Release
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
+            compiler: gcc
+            build_type: Release
+          - os: ubuntu-24.04
             compiler: clang
             build_type: Release
 

--- a/ROADMAP_RELEASES.md
+++ b/ROADMAP_RELEASES.md
@@ -165,7 +165,7 @@ Implements automated release pipeline using GitHub Actions that:
    - Manual workflow dispatch
 
 2. **Build matrix**:
-   - **Linux**: Ubuntu 20.04, 22.04 (gcc, clang)
+   - **Linux**: Ubuntu 22.04, 24.04 (gcc, clang)
    - **macOS**: Latest (AppleClang)
    - **Windows**: Latest (MSVC)
    - **WASM**: Emscripten latest


### PR DESCRIPTION
## Summary
- Replace Ubuntu 20.04 with Ubuntu 22.04 and 24.04 in the release workflow
- Update documentation to reflect the modern Ubuntu LTS versions (22.04 and 24.04)
- Ensure releases are built on actively supported Ubuntu versions with modern toolchains

## Changes
- **`.github/workflows/release.yml`**: Remove ubuntu-20.04, add ubuntu-24.04 with both gcc and clang
- **`ROADMAP_RELEASES.md`**: Update build matrix documentation to reflect Ubuntu 22.04 and 24.04

## Rationale
Ubuntu 20.04 (Focal) is approaching end of standard support and lacks the latest system libraries and toolchains. By updating to Ubuntu 22.04 (Jammy) and 24.04 (Noble), we ensure:
- Access to modern C/C++ compilers and standard libraries
- Better compatibility with current development practices
- Support for the latest security patches and system libraries
- Alignment with the CI workflow which already uses ubuntu-latest with modern compilers (gcc-12/13/14, clang-15/16/17/18)

## Test plan
- [ ] Verify GitHub Actions workflow runs successfully on ubuntu-22.04 and ubuntu-24.04
- [ ] Confirm packages build correctly for both Ubuntu versions
- [ ] Validate that the release artifacts are created as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)